### PR TITLE
entropy stats

### DIFF
--- a/muse/modeling_transformer.py
+++ b/muse/modeling_transformer.py
@@ -1253,18 +1253,21 @@ class MaskGiTUViT(ModelMixin, ConfigMixin):
         logits = self.mlm_layer(hidden_states)
 
         if labels is not None:
-            reduction = "none" if loss_weight is not None else "mean"
-            loss = F.cross_entropy(
+            cross_entropy_per_image = F.cross_entropy(
                 logits.view(-1, self.output_size),
                 labels.view(-1),
                 ignore_index=-100,
                 label_smoothing=label_smoothing,
-                reduction=reduction,
+                reduction="none",
             )
-            if loss_weight is not None:
+
+            if loss_weight is None:
+                loss = cross_entropy_per_image.mean()
+            else:
                 loss_weight = loss_weight.view(-1)
-                loss = ((loss * loss_weight).sum(dim=-1) / loss_weight.sum(dim=-1)).mean()
-            return logits, loss
+                loss = ((cross_entropy_per_image * loss_weight).sum(dim=-1) / loss_weight.sum(dim=-1)).mean()
+
+            return logits, loss, cross_entropy_per_image
         return logits
 
     def _set_gradient_checkpointing(self, module, value=False):

--- a/muse/training_utils.py
+++ b/muse/training_utils.py
@@ -296,7 +296,7 @@ class EMA:
 
 
 # calculates entropy over each pixel distribution
-def entropy_per_percent_masked_bucket(logits, input_ids, mask_id):
+def pixel_entropy_per_percent_masked_bucket(logits, input_ids, mask_id):
     # only calculated entropy over image tokens that were masked in the original image
     masked_tokens = input_ids == mask_id
     num_masked_pixels = masked_tokens.sum(-1)
@@ -324,7 +324,7 @@ def entropy_per_percent_masked_bucket(logits, input_ids, mask_id):
 def image_entropy_per_percent_masked_bucket(logits, input_ids, mask_id):
     # only calculated entropy over image tokens that were masked in the original image
     masked_tokens = input_ids == mask_id
-    num_masked_pixels = masked_tokens.sum(-1)
+    num_masked_pixels = masked_tokens.sum(-1, keepdim=True)
 
     pixel_probs = F.softmax(logits, dim=-1)
     pixel_probs[~masked_tokens] = 0

--- a/muse/training_utils.py
+++ b/muse/training_utils.py
@@ -343,7 +343,15 @@ def image_entropy_per_percent_masked_bucket(logits, input_ids, mask_id):
     return entropy_by_masked_bucket
 
 
-def cross_entropy_per_percent_masked_bucket(cross_entropy_per_image, input_ids, mask_id):
+def cross_entropy_per_percent_masked_bucket(logits, labels, input_ids, mask_id, output_size, label_smoothing):
+    cross_entropy_per_image = F.cross_entropy(
+        logits.view(-1, output_size),
+        labels.view(-1),
+        ignore_index=-100,
+        label_smoothing=label_smoothing,
+        reduction="none",
+    )
+
     total_buckets = 10
     masked_buckets = input_ids_to_masked_buckets(input_ids, mask_id, total_buckets)
 

--- a/setup.py
+++ b/setup.py
@@ -29,6 +29,8 @@ _deps = [
     "datasets",
     "wandb",
     "sentencepiece",  # for T5 tokenizer
+    "plotly",
+    "pandas",
 ]
 
 _extras_dev_deps = [

--- a/training/train_muse.py
+++ b/training/train_muse.py
@@ -24,7 +24,6 @@ from typing import Any, List, Tuple, Union
 
 import numpy as np
 import plotly.express as px
-import plotly.figure_factory as ff
 import torch
 import torch.nn.functional as F
 from accelerate import Accelerator

--- a/training/train_muse.py
+++ b/training/train_muse.py
@@ -609,27 +609,6 @@ def main():
                 else:
                     optimizer.zero_grad(set_to_none=True)
 
-            if (
-                ("log_entropy_every" in config.experiment)
-                and ((global_step + 1) % config.experiment.log_entropy_every == 0)
-                and accelerator.is_main_process
-            ):
-                log_entropy(logits, input_ids, mask_id, accelerator, global_step + 1)
-
-            if (
-                ("log_cross_entropy_every" in config.experiment)
-                and ((global_step + 1) % config.experiment.log_cross_entropy_every == 0)
-                and accelerator.is_main_process
-            ):
-                log_cross_entropy(cross_entropy_per_image, input_ids, mask_id, accelerator, global_step + 1)
-
-            if (
-                ("log_token_probability_distributions_every" in config.experiment)
-                and ((global_step + 1) % config.experiment.log_token_probability_distributions_every == 0)
-                and accelerator.is_main_process
-            ):
-                log_token_probability_distributions(logits, input_ids, mask_id, accelerator, global_step)
-
             # Checks if the accelerator has performed an optimization step behind the scenes
             if accelerator.sync_gradients:
                 if config.training.get("use_ema", False):
@@ -664,6 +643,27 @@ def main():
                     # resetting batch / data time meters per log window
                     batch_time_m.reset()
                     data_time_m.reset()
+
+                if (
+                    ("log_entropy_every" in config.experiment)
+                    and ((global_step + 1) % config.experiment.log_entropy_every == 0)
+                    and accelerator.is_main_process
+                ):
+                    log_entropy(logits, input_ids, mask_id, accelerator, global_step + 1)
+
+                if (
+                    ("log_cross_entropy_every" in config.experiment)
+                    and ((global_step + 1) % config.experiment.log_cross_entropy_every == 0)
+                    and accelerator.is_main_process
+                ):
+                    log_cross_entropy(cross_entropy_per_image, input_ids, mask_id, accelerator, global_step + 1)
+
+                if (
+                    ("log_token_probability_distributions_every" in config.experiment)
+                    and ((global_step + 1) % config.experiment.log_token_probability_distributions_every == 0)
+                    and accelerator.is_main_process
+                ):
+                    log_token_probability_distributions(logits, input_ids, mask_id, accelerator, global_step + 1)
 
                 # Save model checkpoint
                 if (global_step + 1) % config.experiment.save_every == 0:

--- a/training/train_muse.py
+++ b/training/train_muse.py
@@ -742,7 +742,7 @@ def validate_model(model, eval_dataloader, accelerator, global_step, prepare_inp
         input_ids, encoder_hidden_states, labels, _, _, loss_weight = prepare_inputs_and_labels(
             pixel_values, input_ids
         )
-        _, loss = model(
+        _, loss, _ = model(
             input_ids=input_ids, encoder_hidden_states=encoder_hidden_states, labels=labels, loss_weight=loss_weight
         )
         eval_loss += loss.mean()


### PR DESCRIPTION
This adds three main sets of statistics for the entropy of predicted pixel token distributions.

The stats all are broken categorically into buckets of the range of percent masked pixels. As we don't have formal timesteps determining the amount of noise this seemed to be the cleanest dividing line for collections with similar entropy. All stats are hardcoded to use 10 buckets -- bucket 0: 0-0.1 bucket 1: 0.1-0.2, etc...

1) We break the cross entropy w.r.t truth out by buckets in addition to the standard loss which is averaged over all images
2) We plot the average entropy per bucket -- i.e. the entropy for the distribution of each pixel is calculated and then all pixel entropies w/in a bucket are averaged together
3) We plot the full distribution of one pixel per bucket via a histogram and rug chart