### PR TITLE
add flash attn 2

### DIFF
--- a/muse/modeling_transformer.py
+++ b/muse/modeling_transformer.py
@@ -36,6 +36,13 @@ try:
 except ImportError:
     is_xformers_available = False
 
+try:
+    import flash_attn
+
+    is_flash_attn_available = True
+except:
+    is_flash_attn_available = False
+
 
 # classifier free guidance functions
 
@@ -382,6 +389,8 @@ class Attention(nn.Module):
         self.use_memory_efficient_attention_xformers = False
         self.xformers_attention_op = None
 
+        self.use_flash_attn = False
+
     def set_use_memory_efficient_attention_xformers(
         self, use_memory_efficient_attention_xformers: bool, attention_op: Optional[Callable] = None
     ):
@@ -389,6 +398,18 @@ class Attention(nn.Module):
             raise ImportError("Please install xformers to use memory efficient attention")
         self.use_memory_efficient_attention_xformers = use_memory_efficient_attention_xformers
         self.xformers_attention_op = attention_op
+
+        if self.use_flash_attn and self.use_memory_efficient_attention_xformers:
+            raise ValueError("set one and only one of flash attnetion and xformers")
+
+    def set_use_flash_attn(self, use_flash_attn: bool):
+        if use_flash_attn and not is_flash_attn_available:
+            raise ImportError("Please install flash attention")
+
+        self.use_flash_attn = use_flash_attn
+
+        if self.use_flash_attn and self.use_memory_efficient_attention_xformers:
+            raise ValueError("set one and only one of flash attnetion and xformers")
 
     def forward(self, hidden_states, encoder_hidden_states=None, encoder_attention_mask=None):
         if encoder_attention_mask is not None and self.use_memory_efficient_attention_xformers:
@@ -408,6 +429,9 @@ class Attention(nn.Module):
 
         if self.use_memory_efficient_attention_xformers:
             attn_output = xops.memory_efficient_attention(query, key, value, op=self.xformers_attention_op)
+            attn_output = attn_output.view(batch, q_seq_len, self.hidden_size)
+        elif self.use_flash_attn:
+            attn_output = flash_attn.flash_attn_func(query, key, value)
             attn_output = attn_output.view(batch, q_seq_len, self.hidden_size)
         else:
             attention_mask = None

--- a/training/train_muse.py
+++ b/training/train_muse.py
@@ -339,6 +339,9 @@ def main():
     if config.model.enable_xformers_memory_efficient_attention:
         model.enable_xformers_memory_efficient_attention()
 
+    if config.model.get("enable_flash_attn", False):
+        model.enable_flash_attn()
+
     optimizer_config = config.optimizer.params
     learning_rate = optimizer_config.learning_rate
     if optimizer_config.scale_lr:


### PR DESCRIPTION
Marginal improvements over xformers, note that xformers itself isn't a tremendous improvement over vanilla attention. 

We have relatively small sequence lengths of 256 for self attention and 256x77 for cross attention. Our head dimensions of 16 heads of 64 inner dim as well are on the smaller side.


Only linking f8 runs, measurements are same for f16 as we have the same attention block configs/sequence lengths
https://wandb.ai/williamberman/muse/runs/9heg02rd?workspace=user-williamberman
https://wandb.ai/williamberman/muse/runs/2tc3ueir?workspace=user-williamberman
https://wandb.ai/williamberman/muse/runs/f4e8r72x/workspace?workspace=user-williamberman